### PR TITLE
Needed to edit GET ALL to where it would only get products with Archived=0

### DIFF
--- a/BangazonAPI/BangazonAPI/Controllers/ProductController.cs
+++ b/BangazonAPI/BangazonAPI/Controllers/ProductController.cs
@@ -55,7 +55,7 @@ namespace BangazonAPI.Controllers
 
                     
                     
-                    string ProductTable = "FROM Product";
+                    string ProductTable = "FROM Product WHERE Archived = 0";
 
                     command = $"{ProductColumns} {ProductTable}";
                     


### PR DESCRIPTION

# Description

Added code to the GET All products API call would only get products with Archived =0.


## Related Ticket(s)
2

## Steps to Test
You should be to run productTest with no failures. If you do get failures make sure that you do have 1 product created that doesn't have Archived = 1. It is conditionally checking to make sure there is at least one.


# Checklist:
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
