### PR TITLE
Fixed customer query string to include archived property

### DIFF
--- a/BangazonAPI/BangazonAPI/Controllers/CustomerController.cs
+++ b/BangazonAPI/BangazonAPI/Controllers/CustomerController.cs
@@ -105,7 +105,7 @@ namespace BangazonAPI.Controllers
                     //SQL Query To Search For Customer By FirstName, LastName, AccountCreated, LastActive, or Archived
                     if (q != null)
                     {
-                        command += $" WHERE c.FirstName LIKE '%{q}%' OR c.LastName LIKE '%{q}%' OR c.AccountCreated LIKE '%{q}%' OR c.LastActive LIKE '%{q}%' OR c.Archived LIKE '%{q}%'";
+                        command += $" AND c.FirstName LIKE '%{q}%' OR c.LastName LIKE '%{q}%' OR c.AccountCreated LIKE '%{q}%' OR c.LastActive LIKE '%{q}%' OR c.Archived LIKE '%{q}%'";
                     }
 
 


### PR DESCRIPTION
# Description

Rewrote customer SQL query strings to properly include archived property


## Related Ticket(s)
Ticket #1

## Steps to Test
Navigate to ~/customer, look for 'archived=false' on all records.
Navigate to ~/customer/{int}, ~/customer?_include=products, & ~/customer?_include_payments and look for 'archived=false' on all records; no record should display 'archived=true'.


# Checklist:
- [Y ] I have commented my code, particularly in hard-to-understand areas
- [N ] I have made corresponding changes to the documentation
- [? ] My changes generate no new errors
- [N ] I have added tests that prove my fix is effective or that my feature works
- [Y ] New and existing unit tests pass locally with my changes
